### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # WiGLE
 
-Publisher: Splunk \
-Connector Version: 2.0.8 \
-Product Vendor: WiGLE \
-Product Name: WiGLE \
+Publisher: Splunk <br>
+Connector Version: 2.0.8 <br>
+Product Vendor: WiGLE <br>
+Product Name: WiGLE <br>
 Minimum Product Version: 4.9.39220
 
 This app integrates with the WiGLE service to implement investigative actions
@@ -19,14 +19,14 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity <br>
 [lookup network](#action-lookup-network) - Get info about a WiFi SSID
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -41,7 +41,7 @@ No Output
 
 Get info about a WiFi SSID
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Update NOTICE file with updated dependencies
 * Apply pre-commit fixes
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13

--- a/wigle.json
+++ b/wigle.json
@@ -15,7 +15,7 @@
     "package_name": "phantom_wigle",
     "main_module": "wigle_connector.py",
     "min_phantom_version": "4.9.39220",
-    "python_version": "3.9",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cloud v2.53"

--- a/wigle.json
+++ b/wigle.json
@@ -355,5 +355,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)